### PR TITLE
1.8.3.1 (.NET 9.0) update

### DIFF
--- a/HSTempoWasm.csproj
+++ b/HSTempoWasm.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RazorLangVersion>3.0</RazorLangVersion>
     <Title>HSTempoWasm</Title>
     <Authors>Hideki Saito</Authors>
@@ -9,19 +9,19 @@
     <PackageId>HSTempoWasm</PackageId>
     <Description>HSTempo WebAssembly Edition</Description>
     <Copyright>Copyright (c) 2020 Hideki Saito</Copyright>
-    <Version>1.8.2.1</Version>
-    <AssemblyVersion>1.8.2.1</AssemblyVersion>
-    <FileVersion>1.8.2.1</FileVersion>
+    <Version>1.8.3.1</Version>
+    <AssemblyVersion>1.8.3.1</AssemblyVersion>
+    <FileVersion>1.8.3.1</FileVersion>
 	<ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
 	<LangVersion>latest</LangVersion>
 	<Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Fluxor.Blazor.Web" Version="6.1.0" />
-    <PackageReference Include="Fluxor.Blazor.Web.ReduxDevTools" Version="6.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.10" PrivateAssets="all" />
-    <PackageReference Include="System.Net.Http.Json" Version="8.0.1" />
+    <PackageReference Include="Fluxor.Blazor.Web" Version="6.5.2" />
+    <PackageReference Include="Fluxor.Blazor.Web.ReduxDevTools" Version="6.5.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.0" PrivateAssets="all" />
+    <PackageReference Include="System.Net.Http.Json" Version="9.0.0" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
This pull request includes updates to the `HSTempoWasm.csproj` file to upgrade the project to use newer versions of the .NET framework and its dependencies.

### Project and Dependency Upgrades:

* Updated the `TargetFramework` from `net8.0` to `net9.0` to leverage the latest features and improvements in .NET 9.0.
* Updated project versioning from `1.8.2.1` to `1.8.3.1` to reflect the new changes and improvements.
* Upgraded `Fluxor.Blazor.Web` and `Fluxor.Blazor.Web.ReduxDevTools` packages from version `6.1.0` to `6.5.2` for better state management and development tools.
* Updated `Microsoft.AspNetCore.Components.WebAssembly` and `Microsoft.AspNetCore.Components.WebAssembly.DevServer` packages from version `8.0.10` to `9.0.0` to ensure compatibility with .NET 9.0.
* Upgraded `System.Net.Http.Json` package from version `8.0.1` to `9.0.0` to utilize the latest features and improvements in HTTP JSON handling.