### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -3,6 +3,9 @@
 
 name: .NET
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master" ]


### PR DESCRIPTION
Potential fix for [https://github.com/hsaito/HSTempoWasm/security/code-scanning/4](https://github.com/hsaito/HSTempoWasm/security/code-scanning/4)

To resolve the problem, an explicit `permissions` key should be added to the workflow to limit the GITHUB_TOKEN's access to only what is necessary. Since this workflow is only building, restoring, and testing a .NET project, the minimal needed permission is generally `contents: read` (to allow actions/checkout to pull code, but never to modify it). The fix involves adding a `permissions` block at either the workflow root (above `jobs:`) or at the job level (in this case, above or within `jobs.build:`); the most common practice is to place it at the workflow root so it covers the entire workflow unless overridden for specific jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
